### PR TITLE
@yamkim feat: 같은 directive를 한 context에서 사용하는 경우 처리

### DIFF
--- a/conf/nginx_test.conf
+++ b/conf/nginx_test.conf
@@ -48,7 +48,7 @@ http {
   server {
     listen 4242;
     root /Users/yamkim/Documents/42Projects/webserv/www/for_tester;
-    server_n ame webserv.0.1;
+    server_name webserv.0.1;
     keepalive_timeout 6000;
     client_max_body_size 100000000;
     index indexa.html;

--- a/conf/nginx_test.conf
+++ b/conf/nginx_test.conf
@@ -48,7 +48,7 @@ http {
   server {
     listen 4242;
     root /Users/yamkim/Documents/42Projects/webserv/www/for_tester;
-    server_name webserv.0.1;
+    server_n ame webserv.0.1;
     keepalive_timeout 6000;
     client_max_body_size 100000000;
     index indexa.html;

--- a/main/ConnectionSocket.cpp
+++ b/main/ConnectionSocket.cpp
@@ -1,6 +1,6 @@
 #include "ConnectionSocket.hpp"
 
-ConnectionSocket::ConnectionSocket(int listeningSocketFd, const NginxConfig::ServerBlock& serverConf, const NginxConfig::NginxConfig& nginxConf) : Socket(-1, serverConf), _nginxConf(nginxConf) {
+ConnectionSocket::ConnectionSocket(int listeningSocketFd, const NginxConfig::ServerBlock& serverConf, const NginxConfig::GlobalConfig& nginxConf) : Socket(-1, serverConf), _nginxConf(nginxConf) {
     this->_socket = accept(listeningSocketFd, (struct sockaddr *) &this->_socketAddr, &this->_socketLen);
     if (this->_socket == -1) {
         throw ErrorHandler("Error: connection socket error.", ErrorHandler::ALERT, "ConnectionSocket::ConnectionSocket");

--- a/main/ConnectionSocket.hpp
+++ b/main/ConnectionSocket.hpp
@@ -13,12 +13,12 @@ class ConnectionSocket : public Socket {
         HTTPRequestHandler* _req;
         HTTPResponseHandler* _res;
         HTTPData* _data;
-        NginxConfig::NginxConfig _nginxConf;
+        NginxConfig::GlobalConfig _nginxConf;
         long _dynamicBufferSize;
         bool _connectionCloseByServer;
         struct sockaddr_in myAddr;
     public:
-        ConnectionSocket(int listeningSocket, const NginxConfig::ServerBlock& conf, const NginxConfig::NginxConfig& nginxConfig);
+        ConnectionSocket(int listeningSocket, const NginxConfig::ServerBlock& conf, const NginxConfig::GlobalConfig& nginxConfig);
         virtual ~ConnectionSocket();
         HTTPRequestHandler::Phase HTTPRequestProcess(void);
         HTTPResponseHandler::Phase HTTPResponseProcess(void);

--- a/main/HTTPData.hpp
+++ b/main/HTTPData.hpp
@@ -37,7 +37,7 @@ class HTTPData {
         std::string _root;
         std::string _CGIBinary;
         std::string _resAbsoluteFilePath;
-        std::size_t _resContentLength;
+        long _resContentLength;
         std::map<int, std::string> _resStartLineMap;
 
         // Common Data

--- a/main/HTTPHandler.cpp
+++ b/main/HTTPHandler.cpp
@@ -15,7 +15,7 @@ char* HTTPHandler::Buffer::operator*(void) {
     return (_buffer);
 }
 
-HTTPHandler::HTTPHandler(int connectionFd, NginxConfig::ServerBlock serverConf, const NginxConfig::NginxConfig& nginxConf) : _serverConf(serverConf), _nginxConf(nginxConf) {
+HTTPHandler::HTTPHandler(int connectionFd, NginxConfig::ServerBlock serverConf, const NginxConfig::GlobalConfig& nginxConf) : _serverConf(serverConf), _nginxConf(nginxConf) {
 	_connectionFd = connectionFd;
 	_headerString = std::string("");
 }

--- a/main/HTTPHandler.hpp
+++ b/main/HTTPHandler.hpp
@@ -24,7 +24,7 @@ class HTTPHandler {
         int _connectionFd;
         std::string _headerString; // FIXME: deprecated in req handler
         NginxConfig::ServerBlock _serverConf;
-        NginxConfig::NginxConfig _nginxConf;
+        NginxConfig::GlobalConfig _nginxConf;
         class Buffer {
             private:
                 int _bufferSize;
@@ -40,7 +40,7 @@ class HTTPHandler {
         };
 
     public:
-        HTTPHandler(int connectionFd, NginxConfig::ServerBlock serverConf, const NginxConfig::NginxConfig& nginxConf);
+        HTTPHandler(int connectionFd, NginxConfig::ServerBlock serverConf, const NginxConfig::GlobalConfig& nginxConf);
         virtual ~HTTPHandler();
 
         void setGeneralHeader(std::string status);

--- a/main/HTTPRequestHandler.cpp
+++ b/main/HTTPRequestHandler.cpp
@@ -1,6 +1,6 @@
 #include "HTTPRequestHandler.hpp"
 
-HTTPRequestHandler::HTTPRequestHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, NginxConfig::NginxConfig& nginxConf) : HTTPHandler(connectionFd, serverConf, nginxConf) {
+HTTPRequestHandler::HTTPRequestHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, NginxConfig::GlobalConfig& nginxConf) : HTTPHandler(connectionFd, serverConf, nginxConf) {
     _phase = PARSE_STARTLINE;
     _contentLength = -1;
     _contentLengthSum = 0;

--- a/main/HTTPRequestHandler.cpp
+++ b/main/HTTPRequestHandler.cpp
@@ -34,8 +34,8 @@ HTTPRequestHandler::Phase HTTPRequestHandler::process(HTTPData& data, long buffe
                     _phase = PARSE_BODY_CHUNK;
                 }
             } else if (_headers.find("Content-Length") != _headers.end()) {
-                _contentLength = std::atoi(_headers["Content-Length"].c_str());
-                if (_contentLength > std::atoi(_serverConf.dirMap["client_max_body_size"].c_str())) {
+                _contentLength = std::atol(_headers["Content-Length"].c_str());
+                if (_contentLength > std::atol(_serverConf.dirMap["client_max_body_size"].c_str())) {
                     data._statusCode = 413;
                     _phase = FINISH;
                 } else {

--- a/main/HTTPRequestHandler.hpp
+++ b/main/HTTPRequestHandler.hpp
@@ -12,7 +12,7 @@
 
 class HTTPRequestHandler : public HTTPHandler {
     public:
-        HTTPRequestHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, NginxConfig::NginxConfig& nginxConf);
+        HTTPRequestHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, NginxConfig::GlobalConfig& nginxConf);
         virtual ~HTTPRequestHandler();
         typedef enum e_Phase {PARSE_STARTLINE, PARSE_HEADER, PARSE_BODY_NBYTES, PARSE_BODY_CHUNK, REMOVE_CRNF, FINISH} Phase;
         virtual HTTPRequestHandler::Phase process(HTTPData& data, long bufferSize);

--- a/main/HTTPResponseHandler.cpp
+++ b/main/HTTPResponseHandler.cpp
@@ -153,14 +153,14 @@ NginxConfig::LocationBlock HTTPResponseHandler::getMatchingLocationConfiguration
 }
 
 HTTPResponseHandler::Phase HTTPResponseHandler::setInformation(HTTPData& data, int statusCode, const std::string& absPath) {
-    int clientMaxBodySize = _locConf.dirMap["client_max_body_size"].empty() ? -1 : std::atoi(_locConf.dirMap["client_max_body_size"].c_str());
+    int clientMaxBodySize = _locConf.dirMap["client_max_body_size"].empty() ? -1 : std::atol(_locConf.dirMap["client_max_body_size"].c_str());
     if (!_locConf.allowed_method.empty() 
         && find(_locConf.allowed_method.begin(), _locConf.allowed_method.end(), data._reqMethod) == _locConf.allowed_method.end()) {
         data._statusCode = 405;
         setGeneralHeader(data);
         data._resAbsoluteFilePath = absPath;
         data._URIExtension = "html";
-    } else if (clientMaxBodySize >= 0 && clientMaxBodySize < std::atoi(data._reqContentLength.c_str())) {
+    } else if (clientMaxBodySize >= 0 && clientMaxBodySize < std::atol(data._reqContentLength.c_str())) {
         data._statusCode = 413;
         return (PRE_STATUSCODE_CHECK);
     } else {
@@ -185,12 +185,12 @@ HTTPResponseHandler::Phase HTTPResponseHandler::setInformation(HTTPData& data, i
 }
 
 HTTPResponseHandler::Phase HTTPResponseHandler::setFileInDirectory(HTTPData& data, const std::string& absLocPath) {
-    int clientMaxBodySize = _locConf.dirMap["client_max_body_size"].empty() ? -1 : std::atoi(_locConf.dirMap["client_max_body_size"].c_str());
+    int clientMaxBodySize = _locConf.dirMap["client_max_body_size"].empty() ? -1 : std::atol(_locConf.dirMap["client_max_body_size"].c_str());
 
     if (!_locConf.allowed_method.empty() 
         && find(_locConf.allowed_method.begin(), _locConf.allowed_method.end(), data._reqMethod) == _locConf.allowed_method.end()) {
         return setInformation(data, 405, data._root + "/");
-    } else if (clientMaxBodySize >= 0 && clientMaxBodySize < std::atoi(data._reqContentLength.c_str())) {
+    } else if (clientMaxBodySize >= 0 && clientMaxBodySize < std::atol(data._reqContentLength.c_str())) {
         data._statusCode = 413;
         return (PRE_STATUSCODE_CHECK);
     } else {
@@ -229,7 +229,7 @@ HTTPResponseHandler::Phase HTTPResponseHandler::handleProcess(std::string tmpFil
             _phase = setInformation(data, 301, data._URIFilePath + "/");
         } else {
             if (!_locConf._return.empty()) {
-                _phase = setInformation(data, atoi(_locConf._return[0].c_str()), _locConf._return[1]);
+                _phase = setInformation(data, atol(_locConf._return[0].c_str()), _locConf._return[1]);
             } else {
                 _phase = setFileInDirectory(data, data._root + tmpLocPath);
             }

--- a/main/HTTPResponseHandler.cpp
+++ b/main/HTTPResponseHandler.cpp
@@ -1,6 +1,6 @@
 #include "HTTPResponseHandler.hpp"
 
-HTTPResponseHandler::HTTPResponseHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, const NginxConfig::NginxConfig& nginxConf) : HTTPHandler(connectionFd, serverConf, nginxConf) {
+HTTPResponseHandler::HTTPResponseHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, const NginxConfig::GlobalConfig& nginxConf) : HTTPHandler(connectionFd, serverConf, nginxConf) {
     _phase = PRE_STATUSCODE_CHECK;
     _file = NULL;
     _cgi = NULL;

--- a/main/HTTPResponseHandler.hpp
+++ b/main/HTTPResponseHandler.hpp
@@ -22,7 +22,7 @@ class HTTPResponseHandler : public HTTPHandler {
     private:
         HTTPResponseHandler();
     public:
-        HTTPResponseHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, const NginxConfig::NginxConfig& nginxConf);
+        HTTPResponseHandler(int connectionFd, const NginxConfig::ServerBlock& serverConf, const NginxConfig::GlobalConfig& nginxConf);
         virtual ~HTTPResponseHandler();
 
         typedef enum e_Phase {

--- a/main/KernelQueue.hpp
+++ b/main/KernelQueue.hpp
@@ -9,7 +9,7 @@
 #include "ErrorHandler.hpp"
 #include "Socket.hpp"
 
-#define KERNELQUEUE_EVENTS_SIZE 300
+#define KERNELQUEUE_EVENTS_SIZE 60000
 
 class KernelQueue {
     private:

--- a/main/ListeningSocket.cpp
+++ b/main/ListeningSocket.cpp
@@ -1,7 +1,7 @@
 #include "ListeningSocket.hpp"
 
 ListeningSocket::ListeningSocket(const NginxConfig::ServerBlock& serverConf, int backlog) : Socket(-1, serverConf) {
-    _portNum = atoi(Utils::getMapValue(_serverConf.dirMap, "listen").c_str());
+    _portNum = std::atoi(Utils::getMapValue(_serverConf.dirMap, "listen").c_str());
     _backlog = backlog;
 }
 

--- a/main/NginxConfig.cpp
+++ b/main/NginxConfig.cpp
@@ -1,0 +1,316 @@
+#include "NginxConfig.hpp"
+
+void NginxConfig::NginxBlock::checkValidNumberValue(NginxBlock& block, std::string directive) {
+    if (!block.dirMap[directive].empty() && !Parser::isNumber(block.dirMap[directive])) {
+        throw ErrorHandler("Error: invalid value in " + directive + " directive.", ErrorHandler::CRITICAL, "NginxBlock::checkValidNumberValue");
+    }
+}
+
+void NginxConfig::NginxBlock::checkValidErrorPage(const std::vector<std::string>& errorPage) { std::vector<std::string>::const_iterator iter;
+    if (!errorPage.empty()) {
+        for (iter = errorPage.begin(); iter != errorPage.end() - 1; ++iter) {
+            if (!Parser::isNumber(*iter)) {
+                throw ErrorHandler("Error: invalid value " + *iter + " in error_page directive.", ErrorHandler::CRITICAL, "NginxBlock::checkValidErrorPage");
+            }
+        }
+    }
+}
+
+void NginxConfig::NginxBlock::checkAutoindexValue(NginxBlock& block) {
+    if (!block.dirMap["autoindex"].empty() && !(block.dirMap["autoindex"] == "on"
+          || dirMap["autoindex"] == "off")) {
+        throw std::string("Error: invalid argument for autoindex directive.");
+        throw ErrorHandler("Error: invalid argument for autoindex directive.", ErrorHandler::CRITICAL, "NginxBlock::checkAutoindexValue");
+    }
+}
+
+void NginxConfig::TypesBlock::setTypeMap(std::map<std::string, std::string>& typeMap, std::string& type, std::string& value) {
+    std::vector<std::string> tmpVec = Parser::getSplitBySpace(value);
+    for (std::size_t i = 0; i < tmpVec.size(); ++i) {
+        typeMap[tmpVec[i]] = type;
+    }
+}
+
+void NginxConfig::TypesBlock::setTypesBlock() {
+    std::string buf = rawData;
+    std::size_t pos = 0;
+    while (pos < buf.size()) {
+        std::string tmpLine = Parser::getIdentifier(buf, pos, "\n", false);
+        if (Parser::sideSpaceTrim(tmpLine).empty()) {
+            continue ;
+        }
+        std::size_t tmpPos = 0;
+        std::string tmpDir = Parser::getIdentifier(tmpLine, tmpPos, " ", true);
+        std::string value = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
+        setTypeMap(typeMap, tmpDir, value);
+    }
+}
+
+NginxConfig::LocationBlock::LocationBlock(std::string rawData, std::string locationPath, InheritData inheritData) : NginxBlock(rawData), _locationPath(locationPath), _inheritData(inheritData) {
+    setDirectiveTypes();
+    setBlock();
+    checkLocationBlock();
+    inheritDirectives();
+}
+
+void NginxConfig::LocationBlock::setDirectiveTypes() {
+    dirCase.push_back("root");
+    dirCase.push_back("index");
+    dirCase.push_back("autoindex");
+    dirCase.push_back("error_page");
+    dirCase.push_back("client_max_body_size");
+
+    dirCase.push_back("return");
+    dirCase.push_back("try_files");
+    dirCase.push_back("deny");
+    dirCase.push_back("error_page");
+    dirCase.push_back("cgi_pass");
+    dirCase.push_back("allowed_method");
+    dirCase.push_back("inner_proxy");
+}
+
+void NginxConfig::LocationBlock::checkLocationBlock() {
+    checkValidErrorPage(error_page);
+    checkAutoindexValue(*this);
+    checkValidNumberValue(*this, "client_max_body_size");
+    if (_locationPath.empty()) {
+        throw ErrorHandler("Error: location block doesn't have locationPath.", ErrorHandler::CRITICAL, "LocationBlock::checkLocationBlock");
+    }
+    if (!_return.empty()) {
+        if (_return.size() != 2) {
+        throw ErrorHandler("Error: invalid number of arguments in location[return].", ErrorHandler::CRITICAL, "LocationBlock::checkLocationBlock");
+        } else if (!Parser::isNumber(_return[0])) {
+            throw ErrorHandler("Error: invalid status code in location[return] directive.", ErrorHandler::CRITICAL, "LocationBlock::checkLocationBlock");
+        }
+    }
+}
+
+void NginxConfig::LocationBlock::inheritDirectives() {
+    if (dirMap["root"].empty()) {
+        dirMap["root"] = _inheritData.root;
+    }
+    if (index.empty()) {
+        index = _inheritData.index;
+    }
+    if (dirMap["autoindex"].empty()) {
+        dirMap["autoindex"] = _inheritData.autoindex;
+    }
+    if (error_page.empty()) {
+        error_page = _inheritData.error_page;
+    }
+    if (dirMap["client_max_body_size"].empty()) {
+        dirMap["client_max_body_size"] = _inheritData.clientMaxBodySize;
+    }
+}
+
+void NginxConfig::LocationBlock::setBlock() {
+    std::string buf = rawData;
+    std::size_t pos = 0;
+    while (buf[pos]) {
+        std::string tmpLine = Parser::getIdentifier(buf, pos, "\n", false);
+        if (Parser::sideSpaceTrim(tmpLine).empty()) {
+            continue ;
+        }
+        std::size_t tmpPos = 0;
+        std::string tmpDir = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, " ", true));
+        // std::cout << "identifier[location]: [" << tmpDir << "]" << std::endl;
+        if (find(dirCase.begin(), dirCase.end(), tmpDir) == dirCase.end()) {
+            throw ErrorHandler("Error: " + tmpDir + " is not in block[location] list.", ErrorHandler::CRITICAL, "LocationBlock::setBlock");
+        } else if (!dirMap[tmpDir].empty()) {
+            throw ErrorHandler("Error: There is repeated [" + tmpDir + "] directive. in location context", ErrorHandler::CRITICAL, "LocationBlock::setBlock");
+        } else {
+            std::string tmpVal = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
+            if (tmpDir == "index") {
+                index = Parser::getSplitBySpace(tmpVal);
+            } else if (tmpDir == "error_page") {
+                error_page = Parser::getSplitBySpace(tmpVal);
+            } else if (tmpDir == "allowed_method") {
+                allowed_method = Parser::getSplitBySpace(tmpVal);
+            } else if (tmpDir == "inner_proxy") {
+                inner_proxy = Parser::getSplitBySpace(tmpVal);
+            } else if (tmpDir == "return") {
+                _return = Parser::getSplitBySpace(tmpVal);
+            } else {
+                std::vector<std::string> tmpSplit = Parser::getSplitBySpace(tmpVal);
+                if (tmpSplit.size() != 1) {
+                    throw ErrorHandler("Error: invalid number of arguments in location["+ tmpDir + " directive].", ErrorHandler::CRITICAL, "LocationBlock::setBlock");
+                }
+                dirMap[tmpDir] = tmpSplit[0];
+            }
+        }
+    }
+}
+
+NginxConfig::ServerBlock::ServerBlock(std::string rawData) : NginxBlock(rawData) {
+    setDirectiveTypes();
+    setBlock();
+    checkServerBlock();
+}
+
+void NginxConfig::ServerBlock::setDirectiveTypes() {
+    dirCase.push_back("root");
+    dirCase.push_back("index");
+    dirCase.push_back("autoindex");
+    dirCase.push_back("error_page");
+
+    dirCase.push_back("listen");
+    dirCase.push_back("server_name");
+    dirCase.push_back("location");
+    dirCase.push_back("client_max_body_size");
+    dirCase.push_back("keepalive_timeout");
+}
+
+NginxConfig::InheritData NginxConfig::ServerBlock::getInheritData() {
+    InheritData inheritData;
+    if (!dirMap["root"].empty()) {
+        inheritData.root = dirMap["root"];
+    }
+    if (!dirMap["autoindex"].empty()) {
+        inheritData.autoindex = dirMap["autoindex"];
+    }
+    if (!index.empty()) {
+        inheritData.index = index;
+    }
+    if (!error_page.empty()) {
+        inheritData.error_page = error_page;
+    }
+    if (!dirMap["client_max_body_size"].empty()) {
+        inheritData.clientMaxBodySize = dirMap["client_max_body_size"];
+    }
+    return inheritData;
+}
+
+void NginxConfig::ServerBlock::setBlock() {
+    std::string buf = rawData;
+    std::size_t pos = 0;
+    std::size_t blockPos = 0;
+    while (buf[pos]) {
+        std::string tmpLine = Parser::getIdentifier(buf, pos, "\n", false);
+        if (Parser::sideSpaceTrim(tmpLine).empty()) {
+            continue ;
+        }
+        std::size_t tmpPos = 0;
+        std::string tmpDir = Parser::getIdentifier(tmpLine, tmpPos, " ", true);
+        if (find(dirCase.begin(), dirCase.end(), tmpDir) == dirCase.end()) {
+            throw ErrorHandler("Error: " + tmpDir + " is not in context[server] list.", ErrorHandler::CRITICAL, "ServerBlock::setBlock");
+        } else if (tmpDir == "location") {
+            InheritData inheritData = getInheritData();
+            LocationBlock tmpLocationBlock(NginxParser::getBlockContent(buf, blockPos), Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, "{", true)), inheritData);
+            location.push_back(tmpLocationBlock);
+            pos = blockPos;
+        } else if (!dirMap[tmpDir].empty()) {
+            throw ErrorHandler("Error: There is repeated [" + tmpDir + "] directive in server context", ErrorHandler::CRITICAL, "ServerBlock::setBlock");
+        } else {
+            std::string tmpVal = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
+            if (tmpDir == "index") {
+                index = Parser::getSplitBySpace(tmpVal);
+            } else if (tmpDir == "error_page") {
+                error_page = Parser::getSplitBySpace(tmpVal);
+            } else {
+                std::vector<std::string> tmpSplit = Parser::getSplitBySpace(tmpVal);
+                if (tmpSplit.size() != 1) {
+                    throw ErrorHandler("Error: invalid number of arguments in server["+ tmpDir + " directive].", ErrorHandler::CRITICAL, "ServerBlock::setBlock");
+                }
+                dirMap[tmpDir] = tmpSplit[0];
+            }
+        }
+    }
+}
+
+void NginxConfig::ServerBlock::checkServerBlock() {
+    checkValidNumberValue(*this, "listen");
+    checkValidNumberValue(*this, "client_max_body_size");
+    checkValidNumberValue(*this, "keepalive_timeout");
+    checkValidErrorPage(error_page);
+    checkAutoindexValue(*this);
+}
+
+NginxConfig::HttpBlock::HttpBlock(std::string rawData) : NginxBlock(rawData) {
+    setDirectiveTypes();
+    setBlock();
+    checkHttpBlock();
+}
+
+void NginxConfig::HttpBlock::setDirectiveTypes() {
+    dirCase.push_back("charset");
+    dirCase.push_back("default_type");
+    dirCase.push_back("keepalive_timeout");
+    dirCase.push_back("sendfile");
+    dirCase.push_back("types");
+    dirCase.push_back("server");
+}
+
+void NginxConfig::HttpBlock::setBlock() {
+    std::size_t pos = 0;
+    std::size_t blockPos = 0;
+    while (rawData[pos]) {
+        std::string tmpLine = Parser::getIdentifier(rawData, pos, "\n", false);
+        if (Parser::sideSpaceTrim(tmpLine).empty()) {
+            continue ;
+        }
+        std::size_t tmpPos = 0;
+        std::string tmpDir = Parser::getIdentifier(tmpLine, tmpPos, " ", true);
+        if (find(dirCase.begin(), dirCase.end(), tmpDir) == dirCase.end()) {
+            throw ErrorHandler("Error: " + tmpDir + " is not in context[http] list.", ErrorHandler::CRITICAL, "HttpBlock::setBlock");
+        } else if (tmpDir == "server") {
+            ServerBlock tmpServerBlock(NginxParser::getBlockContent(rawData, blockPos));
+            server.push_back(tmpServerBlock);
+            pos = blockPos;
+        } else if (!dirMap[tmpDir].empty()) {
+            throw ErrorHandler("Error: There is repeated [" + tmpDir + "] directive. in http context", ErrorHandler::CRITICAL, "HttpBlock::setBlock");
+        } else if (tmpDir == "types") {
+            TypesBlock tmpTypesBlock(NginxParser::getBlockContent(rawData, blockPos));
+            types = tmpTypesBlock;
+            pos = blockPos;
+        } else {
+            std::string tmpVal = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
+            std::vector<std::string> tmpSplit = Parser::getSplitBySpace(tmpVal);
+            if (tmpSplit.size() != 1) {
+                throw ErrorHandler("Error: invalid number of arguments in http["+ tmpDir + " directive].", ErrorHandler::CRITICAL, "HttpBlock::setBlock");
+            }
+            dirMap[tmpDir] = tmpSplit[0];
+        }
+    }
+}
+
+void NginxConfig::HttpBlock::checkHttpBlock() {
+    std::vector<ServerBlock>::iterator iter;
+    std::vector<std::string> listens;
+    for (iter = server.begin(); iter != server.end(); ++iter) {
+        listens.push_back(iter->dirMap["listen"]);
+    }
+    if (!(std::unique(listens.begin(), listens.end()) == listens.end())) {
+        throw ErrorHandler("Error: There is repeated listening port in different server context", ErrorHandler::CRITICAL, "HttpBlock::checkHttpBlock");
+    }
+}
+
+NginxConfig::GlobalConfig::GlobalConfig(const std::string& fileName) : NginxParser(fileName) {
+    std::size_t pos = 0;
+    std::string identifier;
+
+    while (_rawData[pos]) {
+        std::string tmpLine = getIdentifier(_rawData, pos, "\n", false);
+        if (sideSpaceTrim(tmpLine).empty()) {
+            continue ;
+        }
+
+        std::size_t tmpPos = 0;
+        std::string tmpDir = getIdentifier(tmpLine, tmpPos, " ", true);
+        std::size_t blockPos = 0;
+        if (tmpDir == "http") {
+            HttpBlock tmpHttpBlock(NginxParser::getBlockContent(_rawData, blockPos));
+            _http = tmpHttpBlock;
+            pos = blockPos;
+        } else {
+            std::string tmpVal = getIdentifier(tmpLine, tmpPos, ";", true);
+            if (tmpDir == "user") {
+                _none.user = sideSpaceTrim(tmpVal);
+            } else if (tmpDir == "worker_processes") {
+                _none.worker_processes = sideSpaceTrim(tmpVal);
+            } else {
+                throw ErrorHandler("Error: " + tmpDir + " is not in block[none] list.", ErrorHandler::CRITICAL, "NginxConfig::NginxConfig");
+            }
+        }
+    }
+
+}

--- a/main/NginxConfig.hpp
+++ b/main/NginxConfig.hpp
@@ -11,30 +11,9 @@ class NginxBlock {
         NginxBlock() {};
         NginxBlock(std::string rawData) : rawData(rawData) {};
 
-        void checkValidNumberValue(NginxBlock& block, std::string directive) {
-            if (!block.dirMap[directive].empty() && !Parser::isNumber(block.dirMap[directive])) {
-                throw ErrorHandler("Error: invalid value in " + directive + " directive.", ErrorHandler::CRITICAL, "NginxBlock::checkValidNumberValue");
-            }
-        }
-
-        void checkValidErrorPage(const std::vector<std::string>& errorPage) {
-            std::vector<std::string>::const_iterator iter;
-            if (!errorPage.empty()) {
-                for (iter = errorPage.begin(); iter != errorPage.end() - 1; ++iter) {
-                    if (!Parser::isNumber(*iter)) {
-                        throw ErrorHandler("Error: invalid value " + *iter + " in error_page directive.", ErrorHandler::CRITICAL, "NginxBlock::checkValidErrorPage");
-                    }
-                }
-            }
-        }
-
-        void checkAutoindexValue(NginxBlock& block) {
-            if (!block.dirMap["autoindex"].empty() && !(block.dirMap["autoindex"] == "on"
-                  || this->dirMap["autoindex"] == "off")) {
-                throw std::string("Error: invalid argument for autoindex directive.");
-                throw ErrorHandler("Error: invalid argument for autoindex directive.", ErrorHandler::CRITICAL, "NginxBlock::checkAutoindexValue");
-            }
-        }
+        void checkValidNumberValue(NginxBlock& block, std::string directive);
+        void checkValidErrorPage(const std::vector<std::string>& errorPage);
+        void checkAutoindexValue(NginxBlock& block);
 };
 
 class NoneBlock : public NginxBlock {
@@ -51,28 +30,8 @@ class TypesBlock : public NginxBlock {
         TypesBlock(std::string rawData) : NginxBlock(rawData) {
             setTypesBlock();
         }
-
-        void setTypeMap(std::map<std::string, std::string>& typeMap, std::string& type, std::string& value) {
-            std::vector<std::string> tmpVec = Parser::getSplitBySpace(value);
-            for (std::size_t i = 0; i < tmpVec.size(); ++i) {
-                typeMap[tmpVec[i]] = type;
-            }
-        }
-
-        void setTypesBlock() {
-            std::string buf = this->rawData;
-            std::size_t pos = 0;
-            while (pos < buf.size()) {
-                std::string tmpLine = Parser::getIdentifier(buf, pos, "\n", false);
-                if (Parser::sideSpaceTrim(tmpLine).empty()) {
-                    continue ;
-                }
-                std::size_t tmpPos = 0;
-                std::string tmpDir = Parser::getIdentifier(tmpLine, tmpPos, " ", true);
-                std::string value = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
-                setTypeMap(this->typeMap, tmpDir, value);
-            }
-        }
+        void setTypeMap(std::map<std::string, std::string>& typeMap, std::string& type, std::string& value);        
+        void setTypesBlock();
 };
 
 typedef struct s_InheritData {
@@ -95,100 +54,11 @@ class LocationBlock : public NginxBlock {
         InheritData _inheritData;
 
         LocationBlock() {}
-        LocationBlock(std::string rawData, std::string locationPath, InheritData inheritData) : NginxBlock(rawData), _locationPath(locationPath), _inheritData(inheritData) {
-            setDirectiveTypes();
-            setBlock();
-            checkLocationBlock();
-            inheritDirectives();
-        }
-
-        void setDirectiveTypes() {
-            this->dirCase.push_back("root");
-            this->dirCase.push_back("index");
-            this->dirCase.push_back("autoindex");
-            this->dirCase.push_back("error_page");
-            this->dirCase.push_back("client_max_body_size");
-
-            this->dirCase.push_back("return");
-            this->dirCase.push_back("try_files");
-            this->dirCase.push_back("deny");
-            this->dirCase.push_back("error_page");
-            this->dirCase.push_back("cgi_pass");
-            this->dirCase.push_back("allowed_method");
-            this->dirCase.push_back("inner_proxy");
-        }
-
-        void checkLocationBlock() {
-            checkValidErrorPage(this->error_page);
-            checkAutoindexValue(*this);
-            checkValidNumberValue(*this, "client_max_body_size");
-            if (this->_locationPath.empty()) {
-                throw ErrorHandler("Error: location block doesn't have locationPath.", ErrorHandler::CRITICAL, "LocationBlock::checkLocationBlock");
-            }
-            if (!this->_return.empty()) {
-                if (this->_return.size() != 2) {
-                throw ErrorHandler("Error: invalid number of arguments in location[return].", ErrorHandler::CRITICAL, "LocationBlock::checkLocationBlock");
-                } else if (!Parser::isNumber(this->_return[0])) {
-                    throw ErrorHandler("Error: invalid status code in location[return] directive.", ErrorHandler::CRITICAL, "LocationBlock::checkLocationBlock");
-                }
-            }
-        }
-
-        void inheritDirectives() {
-            if (this->dirMap["root"].empty()) {
-                this->dirMap["root"] = _inheritData.root;
-            }
-            if (this->index.empty()) {
-                this->index = _inheritData.index;
-            }
-            if (this->dirMap["autoindex"].empty()) {
-                this->dirMap["autoindex"] = _inheritData.autoindex;
-            }
-            if (this->error_page.empty()) {
-                this->error_page = _inheritData.error_page;
-            }
-            if (this->dirMap["client_max_body_size"].empty()) {
-                this->dirMap["client_max_body_size"] = _inheritData.clientMaxBodySize;
-            }
-        }
-
-        void setBlock() {
-            std::string buf = this->rawData;
-            std::size_t pos = 0;
-            while (buf[pos]) {
-                std::string tmpLine = Parser::getIdentifier(buf, pos, "\n", false);
-                if (Parser::sideSpaceTrim(tmpLine).empty()) {
-                    continue ;
-                }
-                std::size_t tmpPos = 0;
-                std::string tmpDir = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, " ", true));
-                // std::cout << "identifier[location]: [" << tmpDir << "]" << std::endl;
-                if (find(this->dirCase.begin(), this->dirCase.end(), tmpDir) == this->dirCase.end()) {
-                    throw ErrorHandler("Error: " + tmpDir + " is not in block[location] list.", ErrorHandler::CRITICAL, "LocationBlock::setBlock");
-                } else if (!dirMap[tmpDir].empty()) {
-                    throw ErrorHandler("Error: There is repeated [" + tmpDir + "] directive. in location context", ErrorHandler::CRITICAL, "LocationBlock::setBlock");
-                } else {
-                    std::string tmpVal = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
-                    if (tmpDir == "index") {
-                        this->index = Parser::getSplitBySpace(tmpVal);
-                    } else if (tmpDir == "error_page") {
-                        this->error_page = Parser::getSplitBySpace(tmpVal);
-                    } else if (tmpDir == "allowed_method") {
-                        this->allowed_method = Parser::getSplitBySpace(tmpVal);
-                    } else if (tmpDir == "inner_proxy") {
-                        this->inner_proxy = Parser::getSplitBySpace(tmpVal);
-                    } else if (tmpDir == "return") {
-                        this->_return = Parser::getSplitBySpace(tmpVal);
-                    } else {
-                        std::vector<std::string> tmpSplit = Parser::getSplitBySpace(tmpVal);
-                        if (tmpSplit.size() != 1) {
-                            throw ErrorHandler("Error: invalid number of arguments in location["+ tmpDir + " directive].", ErrorHandler::CRITICAL, "LocationBlock::setBlock");
-                        }
-                        this->dirMap[tmpDir] = tmpSplit[0];
-                    }
-                }
-            }
-        }
+        LocationBlock(std::string rawData, std::string locationPath, InheritData inheritData);
+        void setDirectiveTypes();
+        void checkLocationBlock();
+        void inheritDirectives();
+        void setBlock();
 };
 
 class ServerBlock : public NginxBlock{
@@ -199,91 +69,14 @@ class ServerBlock : public NginxBlock{
         std::vector<class LocationBlock> location;
 
         ServerBlock() {}
-        ServerBlock(std::string rawData) : NginxBlock(rawData) {
-            setDirectiveTypes();
-            setBlock();
-            checkServerBlock();
-        }
-
-        void setDirectiveTypes() {
-            this->dirCase.push_back("root");
-            this->dirCase.push_back("index");
-            this->dirCase.push_back("autoindex");
-            this->dirCase.push_back("error_page");
-
-            this->dirCase.push_back("listen");
-            this->dirCase.push_back("server_name");
-            this->dirCase.push_back("location");
-            this->dirCase.push_back("client_max_body_size");
-            this->dirCase.push_back("keepalive_timeout");
-        }
-
-        InheritData getInheritData() {
-            InheritData inheritData;
-            if (!this->dirMap["root"].empty()) {
-                inheritData.root = this->dirMap["root"];
-            }
-            if (!this->dirMap["autoindex"].empty()) {
-                inheritData.autoindex = this->dirMap["autoindex"];
-            }
-            if (!this->index.empty()) {
-                inheritData.index = this->index;
-            }
-            if (!this->error_page.empty()) {
-                inheritData.error_page = this->error_page;
-            }
-            if (!this->dirMap["client_max_body_size"].empty()) {
-                inheritData.clientMaxBodySize = this->dirMap["client_max_body_size"];
-            }
-            return inheritData;
-        }
-
-        void setBlock() {
-            std::string buf = this->rawData;
-            std::size_t pos = 0;
-            std::size_t blockPos = 0;
-            while (buf[pos]) {
-                std::string tmpLine = Parser::getIdentifier(buf, pos, "\n", false);
-                if (Parser::sideSpaceTrim(tmpLine).empty()) {
-                    continue ;
-                }
-                std::size_t tmpPos = 0;
-                std::string tmpDir = Parser::getIdentifier(tmpLine, tmpPos, " ", true);
-                if (find(this->dirCase.begin(), this->dirCase.end(), tmpDir) == this->dirCase.end()) {
-                    throw ErrorHandler("Error: " + tmpDir + " is not in context[server] list.", ErrorHandler::CRITICAL, "ServerBlock::setBlock");
-                } else if (tmpDir == "location") {
-                    InheritData inheritData = getInheritData();
-                    LocationBlock tmpLocationBlock(NginxParser::getBlockContent(buf, blockPos), Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, "{", true)), inheritData);
-                    this->location.push_back(tmpLocationBlock);
-                    pos = blockPos;
-                } else if (!dirMap[tmpDir].empty()) {
-                    throw ErrorHandler("Error: There is repeated [" + tmpDir + "] directive in server context", ErrorHandler::CRITICAL, "ServerBlock::setBlock");
-                } else {
-                    std::string tmpVal = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
-                    if (tmpDir == "index") {
-                        this->index = Parser::getSplitBySpace(tmpVal);
-                    } else if (tmpDir == "error_page") {
-                        this->error_page = Parser::getSplitBySpace(tmpVal);
-                    } else {
-                        std::vector<std::string> tmpSplit = Parser::getSplitBySpace(tmpVal);
-                        if (tmpSplit.size() != 1) {
-                            throw ErrorHandler("Error: invalid number of arguments in server["+ tmpDir + " directive].", ErrorHandler::CRITICAL, "ServerBlock::setBlock");
-                        }
-                        this->dirMap[tmpDir] = tmpSplit[0];
-                    }
-                }
-            }
-        }
-
-        void checkServerBlock () {
-            checkValidNumberValue(*this, "listen");
-            checkValidNumberValue(*this, "client_max_body_size");
-            checkValidNumberValue(*this, "keepalive_timeout");
-            checkValidErrorPage(this->error_page);
-            checkAutoindexValue(*this);
-        }
+        ServerBlock(std::string rawData);
+        void setDirectiveTypes();        
+        InheritData getInheritData();
+        void setBlock();
+        void checkServerBlock();
 
 };
+
 class HttpBlock : public NginxBlock{
     public:
         std::vector<std::string> dirCase;
@@ -291,102 +84,20 @@ class HttpBlock : public NginxBlock{
         class TypesBlock types;
     
         HttpBlock() {}
-        HttpBlock(std::string rawData) : NginxBlock(rawData) {
-            setDirectiveTypes();
-            setBlock();
-            checkHttpBlock();
-        }
-
-        void setDirectiveTypes() {
-            this->dirCase.push_back("charset");
-            this->dirCase.push_back("default_type");
-            this->dirCase.push_back("keepalive_timeout");
-            this->dirCase.push_back("sendfile");
-            this->dirCase.push_back("types");
-            this->dirCase.push_back("server");
-        }
-
-        void setBlock() {
-            std::size_t pos = 0;
-            std::size_t blockPos = 0;
-            while (this->rawData[pos]) {
-                std::string tmpLine = Parser::getIdentifier(this->rawData, pos, "\n", false);
-                if (Parser::sideSpaceTrim(tmpLine).empty()) {
-                    continue ;
-                }
-                std::size_t tmpPos = 0;
-                std::string tmpDir = Parser::getIdentifier(tmpLine, tmpPos, " ", true);
-                if (find(this->dirCase.begin(), this->dirCase.end(), tmpDir) == this->dirCase.end()) {
-                    throw ErrorHandler("Error: " + tmpDir + " is not in context[http] list.", ErrorHandler::CRITICAL, "HttpBlock::setBlock");
-                } else if (tmpDir == "server") {
-                    ServerBlock tmpServerBlock(NginxParser::getBlockContent(this->rawData, blockPos));
-                    this->server.push_back(tmpServerBlock);
-                    pos = blockPos;
-                } else if (!dirMap[tmpDir].empty()) {
-                    throw ErrorHandler("Error: There is repeated [" + tmpDir + "] directive. in http context", ErrorHandler::CRITICAL, "HttpBlock::setBlock");
-                } else if (tmpDir == "types") {
-                    TypesBlock tmpTypesBlock(NginxParser::getBlockContent(this->rawData, blockPos));
-                    this->types = tmpTypesBlock;
-                    pos = blockPos;
-                } else {
-                    std::string tmpVal = Parser::sideSpaceTrim(Parser::getIdentifier(tmpLine, tmpPos, ";", true));
-                    std::vector<std::string> tmpSplit = Parser::getSplitBySpace(tmpVal);
-                    if (tmpSplit.size() != 1) {
-                        throw ErrorHandler("Error: invalid number of arguments in http["+ tmpDir + " directive].", ErrorHandler::CRITICAL, "HttpBlock::setBlock");
-                    }
-                    this->dirMap[tmpDir] = tmpSplit[0];
-                }
-            }
-        }
-
-        void checkHttpBlock() {
-            std::vector<ServerBlock>::iterator iter;
-            std::vector<std::string> listens;
-            for (iter = server.begin(); iter != server.end(); ++iter) {
-                listens.push_back(iter->dirMap["listen"]);
-            }
-            if (!(std::unique(listens.begin(), listens.end()) == listens.end())) {
-                throw ErrorHandler("Error: There is repeated listening port in different server context", ErrorHandler::CRITICAL, "HttpBlock::checkHttpBlock");
-            }
-        }
+        HttpBlock(std::string rawData);
+        void setDirectiveTypes();
+        void setBlock();
+        void checkHttpBlock();
 };
 
-class NginxConfig : public NginxParser {
+class GlobalConfig : public NginxParser {
     public:
     public:
         class NoneBlock _none;
         class HttpBlock _http;
 
-        NginxConfig(const std::string& fileName) : NginxParser(fileName) {
-            std::size_t pos = 0;
-            std::string identifier;
+        GlobalConfig(const std::string& fileName);
 
-            while (_rawData[pos]) {
-                std::string tmpLine = getIdentifier(_rawData, pos, "\n", false);
-                if (sideSpaceTrim(tmpLine).empty()) {
-                    continue ;
-                }
-
-                std::size_t tmpPos = 0;
-                std::string tmpDir = getIdentifier(tmpLine, tmpPos, " ", true);
-                std::size_t blockPos = 0;
-                if (tmpDir == "http") {
-                    HttpBlock tmpHttpBlock(NginxParser::getBlockContent(_rawData, blockPos));
-                    _http = tmpHttpBlock;
-                    pos = blockPos;
-                } else {
-                    std::string tmpVal = getIdentifier(tmpLine, tmpPos, ";", true);
-                    if (tmpDir == "user") {
-                        _none.user = sideSpaceTrim(tmpVal);
-                    } else if (tmpDir == "worker_processes") {
-                        _none.worker_processes = sideSpaceTrim(tmpVal);
-                    } else {
-                        throw ErrorHandler("Error: " + tmpDir + " is not in block[none] list.", ErrorHandler::CRITICAL, "NginxConfig::NginxConfig");
-                    }
-                }
-            }
-
-        }
 };
 }
 #endif

--- a/main/NginxParser.cpp
+++ b/main/NginxParser.cpp
@@ -1,0 +1,50 @@
+#include "NginxParser.hpp"
+
+NginxParser::NginxParser(const std::string& fileName) : Parser(fileName) {
+}
+
+void NginxParser::skipComment(const std::string& str, std::size_t &commentPos) {
+    while (str[commentPos]) {
+        if (str[commentPos] != '\n') {
+            ++commentPos;
+        } else {
+            return ;
+        }
+    }
+}
+
+void NginxParser::findBlockSet(const std::string& buf, std::stack<int>st, std::vector<std::pair<std::string, std::size_t> >& vec, std::size_t& pos) {
+    while (!(buf[pos] == '\0' || buf[pos] == '{' || buf[pos] == '}')) {
+        ++pos;
+    }
+    if (buf[pos] == '{') {
+        st.push(1);
+        vec.push_back(std::make_pair("{", pos));
+    } else if (buf[pos] == '}') {
+        if (st.top() == 1) {
+            st.pop();
+        }
+        vec.push_back(std::make_pair("}", pos));
+    }
+    if (st.empty()) {
+        return ;
+    }
+    pos += 1;
+    findBlockSet(buf, st, vec, pos);
+}
+
+std::string NginxParser::getBlockContent(const std::string& buf, std::size_t& pos) {
+    std::vector<std::pair<std::string, std::size_t> > blockSet;
+    std::stack<int> st;
+
+    findBlockSet(buf, st, blockSet, pos);
+    if (blockSet.empty()) {
+        throw std::string("Error: bracket is empty. NginxParser::getBlockContent");
+        throw ErrorHandler("Error: bracket is empty. NginxParser::getBlockContent", ErrorHandler::CRITICAL, "NginxParser::getBlockContent");
+    }
+    std::size_t blockBeg = blockSet.begin()->second;
+    std::size_t blockEnd = (blockSet.end() - 1)->second;
+    pos = blockEnd + 1;
+
+    return buf.substr(blockBeg + 1, blockEnd - blockBeg - 1);
+}

--- a/main/NginxParser.hpp
+++ b/main/NginxParser.hpp
@@ -52,6 +52,7 @@ class NginxParser : public Parser {
             findBlockSet(buf, st, blockSet, pos);
             if (blockSet.empty()) {
                 throw std::string("Error: bracket is empty. NginxParser::getBlockContent");
+                throw ErrorHandler("Error: bracket is empty. NginxParser::getBlockContent", ErrorHandler::CRITICAL, "NginxParser::getBlockContent");
             }
             std::size_t blockBeg = blockSet.begin()->second;
             std::size_t blockEnd = (blockSet.end() - 1)->second;

--- a/main/NginxParser.hpp
+++ b/main/NginxParser.hpp
@@ -4,62 +4,10 @@
 #include "Parser.hpp"
 
 class NginxParser : public Parser {
-    private:
-
-    public:
-        NginxParser(const std::string& fileName) : Parser(fileName) {
-        }
-
-        void skipComment (const std::string& str, std::size_t &commentPos) {
-            while (str[commentPos]) {
-                if (str[commentPos] != '\n') {
-                    ++commentPos;
-                } else {
-                    return ;
-                }
-            }
-        }
-
-        // 매개변수 pos 이후로 브라켓 세트를 만듭니다.
-        // 열린 브라켓인지 닫힌 브라켓인지, 각 브라켓의 index는 무엇인지를 함께 담습니다.
-        static void findBlockSet(const std::string& buf, std::stack<int>st, std::vector<std::pair<std::string, std::size_t> >& vec, std::size_t& pos) {
-            while (!(buf[pos] == '\0' || buf[pos] == '{' || buf[pos] == '}')) {
-                ++pos;
-            }
-            if (buf[pos] == '{') {
-                st.push(1);
-                vec.push_back(std::make_pair("{", pos));
-            } else if (buf[pos] == '}') {
-                if (st.top() == 1) {
-                    st.pop();
-                }
-                vec.push_back(std::make_pair("}", pos));
-            }
-            if (st.empty()) {
-                return ;
-            }
-            pos += 1;
-            findBlockSet(buf, st, vec, pos);
-        }
-
-        // 매개변수 pos 이후로 가장 큰 블록을 읽어옵니다.
-        // 내부에 블록이 중첩되어 있더라도 이들을 포함한 큰 블록을 읽어옵니다.
-        static std::string getBlockContent(const std::string& buf, std::size_t& pos) {
-            std::vector<std::pair<std::string, std::size_t> > blockSet;
-            std::stack<int> st;
-
-            // std::cout << "buf[getBlockContent]: " << buf << std::endl;
-            findBlockSet(buf, st, blockSet, pos);
-            if (blockSet.empty()) {
-                throw std::string("Error: bracket is empty. NginxParser::getBlockContent");
-                throw ErrorHandler("Error: bracket is empty. NginxParser::getBlockContent", ErrorHandler::CRITICAL, "NginxParser::getBlockContent");
-            }
-            std::size_t blockBeg = blockSet.begin()->second;
-            std::size_t blockEnd = (blockSet.end() - 1)->second;
-            pos = blockEnd + 1;
-
-            return buf.substr(blockBeg + 1, blockEnd - blockBeg - 1);
-        }
-
+    public:        
+        NginxParser(const std::string& fileName);
+        void skipComment(const std::string& str, std::size_t &commentPos);
+        static void findBlockSet(const std::string& buf, std::stack<int>st, std::vector<std::pair<std::string, std::size_t> >& vec, std::size_t& pos);
+        static std::string getBlockContent(const std::string& buf, std::size_t& pos);
 };
 #endif

--- a/main/Parser.cpp
+++ b/main/Parser.cpp
@@ -1,0 +1,117 @@
+#include "Parser.hpp"
+Parser::Parser(const std::string& fileName) : _fileName(fileName) {
+    _rawData = "";
+    std::ifstream readFile;
+
+    readFile.open(this->_fileName);
+    if (!readFile.is_open()){
+        throw ErrorHandler("Error: Configuration open error.", ErrorHandler::CRITICAL, "Parser::Parser");
+    }
+    while (!readFile.eof()) {
+        std::string tmp;
+        getline(readFile, tmp);
+        this->_rawData += tmp;
+        this->_rawData += "\n";
+    }
+    readFile.close();
+
+    if (!isValidBlockSet(this->_rawData)) {
+        throw ErrorHandler("Error: bracket pair is not matched.", ErrorHandler::CRITICAL, "Parser::Parser");
+    }
+}
+Parser::~Parser(){};
+
+const std::string& Parser::getRawData() const{
+    return _rawData;
+}
+
+bool Parser::isValidBlockSet (const std::string& buf) {
+    std::size_t pos = 0;
+
+    int leftBracketNum = 0;
+    int rightBracketNum = 0;
+
+    while (buf[pos]) {
+        if (buf[pos] == '{') {
+            leftBracketNum++;
+        } else if (buf[pos] == '}') {
+            rightBracketNum++;
+        }
+        ++pos;
+    }
+    return leftBracketNum == rightBracketNum;
+}
+
+std::string Parser::leftSpaceTrim(std::string s) {
+    const std::string drop = " ";
+    return s.erase(0, s.find_first_not_of(drop));
+}
+
+std::string Parser::rightSpaceTrim(std::string s) {
+    const std::string drop = " ";
+    return s.erase(s.find_last_not_of(drop)+1);
+}
+
+std::string Parser::sideSpaceTrim(std::string s) {
+    const std::string drop = " ";
+    std::string ret = s.erase(s.find_last_not_of(drop)+1);
+    ret = ret.erase(0, ret.find_first_not_of(drop));
+    return ret;
+}
+
+bool Parser::isCharInString(const std::string& str, const char c) {
+    std::size_t itr = 0;
+    while (str[itr]) {
+        if (str[itr] == c)
+            return true;
+        ++itr;
+    }
+    return false;
+} 
+
+std::string Parser::getIdentifier(const std::string str, std::size_t& endPos, std::string delimiter, bool checker)
+{
+    size_t wordSize = 0;
+
+    if (checker && str.find(delimiter) == std::string::npos) {
+        std::cout << "[DEBUG] String: " << str << std::endl;
+        throw ErrorHandler("Error: There is no delimiter[" + delimiter + "].", ErrorHandler::CRITICAL, "Parser::getIdentifier");
+    }
+
+    while ((str[endPos] != '\0') && isCharInString(delimiter, str[endPos])) {
+        ++endPos;
+    }
+    size_t begPos = endPos;
+    while ((str[endPos] != '\0') && !isCharInString(delimiter, str[endPos])) {
+        ++wordSize;
+        ++endPos;
+    }
+    return str.substr(begPos, wordSize);
+}
+
+std::vector<std::string> Parser::getSplitBySpace(std::string str) {
+    std::vector<std::string> ret;
+
+    std::size_t pos = 0;
+    // std::cout << "[DEBUG] tmpLine with space: " << str << std::endl; 
+    while (pos < str.size()) {
+        // std::string tmp = getIdentifier(str, pos, " \r\n");
+        std::string tmp = getIdentifier(str, pos, " ", false);
+        if (tmp.empty()) {
+            break ;
+        }
+        ret.push_back(tmp);
+    }
+    return ret; 
+}
+
+bool Parser::isNumber(const std::string& str) {
+    int pos = 0;
+    while (str[pos]) {
+        if (!(str[pos] >= '0' && str[pos] <= '9')) {
+            return false;
+        }
+        ++pos;
+    }
+    return true;
+}

--- a/main/Parser.hpp
+++ b/main/Parser.hpp
@@ -15,127 +15,16 @@ class Parser {
         std::string _fileName;
 
     public:
-        Parser(const std::string& fileName) : _fileName(fileName) {
-            _rawData = "";
-            std::ifstream readFile;
-
-            readFile.open(this->_fileName);
-            if (!readFile.is_open()){
-                throw ErrorHandler("Error: Configuration open error.", ErrorHandler::CRITICAL, "Parser::Parser");
-            }
-            while (!readFile.eof()) {
-                std::string tmp;
-                getline(readFile, tmp);
-                this->_rawData += tmp;
-                this->_rawData += "\n";
-            }
-            readFile.close();
-
-            if (!isValidBlockSet(this->_rawData)) {
-                throw ErrorHandler("Error: bracket pair is not matched.", ErrorHandler::CRITICAL, "Parser::Parser");
-            }
-        }
-        virtual ~Parser(){};
-
-        const std::string& getRawData() const{
-            return _rawData;
-        }
-
-        bool isValidBlockSet (const std::string& buf) {
-            std::size_t pos = 0;
-
-            int leftBracketNum = 0;
-            int rightBracketNum = 0;
-
-            while (buf[pos]) {
-                if (buf[pos] == '{') {
-                    leftBracketNum++;
-                } else if (buf[pos] == '}') {
-                    rightBracketNum++;
-                }
-                ++pos;
-            }
-            return (leftBracketNum == rightBracketNum);
-        }
-
-        std::string leftSpaceTrim(std::string s) {
-            const std::string drop = " ";
-            return s.erase(0, s.find_first_not_of(drop));
-        }
-
-        std::string rightSpaceTrim(std::string s) {
-            const std::string drop = " ";
-            return s.erase(s.find_last_not_of(drop)+1);
-        }
-
-        static std::string sideSpaceTrim(std::string s) {
-            const std::string drop = " ";
-            std::string ret = s.erase(s.find_last_not_of(drop)+1);
-            ret = ret.erase(0, ret.find_first_not_of(drop));
-            return ret;
-        }
-
-        static bool isCharInString(const std::string& str, const char c) {
-            std::size_t itr = 0;
-            while (str[itr]) {
-                if (str[itr] == c)
-                    return true;
-                ++itr;
-            }
-            return false;
-        } 
-
-        // 매개변수 delimiter의 요소라면, 이를 기준으로 split 후에 첫 단어만 가지고 옵니다.
-        // [          listen     5000;]이고, delimit이 " "라면, listen만 가지고 옵니다.
-        // 찾으려는 delimiter가 없는 경우, error를 반환합니다.
-        // ex) text/css    css => ';'이 없는 경우로, str
-        // 문자열에 delimiter가 있어야하는 경우 checker를 true로 하여, 해당하지 않는 경우 거릅니다.
-        static std::string	getIdentifier(const std::string str, std::size_t& endPos, std::string delimiter, bool checker)
-        {
-            size_t wordSize = 0;
-
-            if (checker && str.find(delimiter) == std::string::npos) {
-                std::cout << "[DEBUG] String: " << str << std::endl;
-                throw ErrorHandler("Error: There is no delimiter[" + delimiter + "].", ErrorHandler::CRITICAL, "Parser::getIdentifier");
-            }
-
-            while ((str[endPos] != '\0') && isCharInString(delimiter, str[endPos])) {
-                ++endPos;
-            }
-            size_t begPos = endPos;
-            while ((str[endPos] != '\0') && !isCharInString(delimiter, str[endPos])) {
-                ++wordSize;
-                ++endPos;
-            }
-
-            return (str.substr(begPos, wordSize));
-        }
-
-        static std::vector<std::string> getSplitBySpace(std::string str) {
-            std::vector<std::string> ret;
-
-            std::size_t pos = 0;
-            // std::cout << "[DEBUG] tmpLine with space: " << str << std::endl; 
-            while (pos < str.size()) {
-                // std::string tmp = getIdentifier(str, pos, " \r\n");
-                std::string tmp = getIdentifier(str, pos, " ", false);
-                if (tmp.empty()) {
-                    break ;
-                }
-                ret.push_back(tmp);
-            }
-            return ret; 
-        }
-
-        static bool isNumber(const std::string& str) {
-            int pos = 0;
-            while (str[pos]) {
-                if (!(str[pos] >= '0' && str[pos] <= '9')) {
-                    return false;
-                }
-                ++pos;
-            }
-            return true;
-        }
+        Parser(const std::string& fileName);
+        ~Parser();
+        const std::string& getRawData() const;
+        bool isValidBlockSet (const std::string& buf);
+        std::string leftSpaceTrim(std::string s);
+        std::string rightSpaceTrim(std::string s);
+        static std::string sideSpaceTrim(std::string s);
+        static bool isCharInString(const std::string& str, const char c);
+        static std::string	getIdentifier(const std::string str, std::size_t& endPos, std::string delimiter, bool checker);
+        static std::vector<std::string> getSplitBySpace(std::string str);
+        static bool isNumber(const std::string& str);
 };
 #endif

--- a/main/Parser.hpp
+++ b/main/Parser.hpp
@@ -21,7 +21,7 @@ class Parser {
 
             readFile.open(this->_fileName);
             if (!readFile.is_open()){
-                throw std::string("Error: Configuration open error.");
+                throw ErrorHandler("Error: Configuration open error.", ErrorHandler::CRITICAL, "Parser::Parser");
             }
             while (!readFile.eof()) {
                 std::string tmp;
@@ -32,7 +32,7 @@ class Parser {
             readFile.close();
 
             if (!isValidBlockSet(this->_rawData)) {
-                throw std::string("Error: bracket pair is not matched.");
+                throw ErrorHandler("Error: bracket pair is not matched.", ErrorHandler::CRITICAL, "Parser::Parser");
             }
         }
         virtual ~Parser(){};
@@ -96,8 +96,7 @@ class Parser {
 
             if (checker && str.find(delimiter) == std::string::npos) {
                 std::cout << "[DEBUG] String: " << str << std::endl;
-                throw std::string("Error: There is no delimiter[" + delimiter + "]. Parser::getIdentifier");
-                // throw ErrorHandler(std::string("Error: There is no delimiter["+ delimiter + "].").c_str(), ErrorHandler::CRITICAL, "Parser::getIdentifier");
+                throw ErrorHandler("Error: There is no delimiter[" + delimiter + "].", ErrorHandler::CRITICAL, "Parser::getIdentifier");
             }
 
             while ((str[endPos] != '\0') && isCharInString(delimiter, str[endPos])) {

--- a/main/Utils.hpp
+++ b/main/Utils.hpp
@@ -1,7 +1,7 @@
 #ifndef UTILS_HPP
 #define UTILS_HPP
 
-//#include "NginxConfig.hpp"
+//#include "GlobalConfig.hpp"
 #include <string>
 #include <map>
 #include <sstream>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -30,9 +30,8 @@ int main(int argc, char *argv[])
 
     try {
         NginxConfig::GlobalConfig nginxConfig(confPath);
-#if 0
         for (std::size_t i = 0; i < nginxConfig._http.server.size(); i++) {
-            ListeningSocket* lSocket = new ListeningSocket(nginxConfig._http.server[i], 32768);
+            ListeningSocket* lSocket = new ListeningSocket(nginxConfig._http.server[i], 60000);
             if (lSocket->runSocket())
                 return (1);
             kq.addReadEvent(lSocket->getSocket(), reinterpret_cast<void*>(lSocket));
@@ -87,7 +86,6 @@ int main(int argc, char *argv[])
             }
             timer.CheckTimer(ConnectionSocket::ConnectionSocketKiller);
         }
-#endif
     } catch (const std::exception& error) {
         std::cerr << error.what() << std::endl;
         return (1);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
     }
 
     try {
-        NginxConfig::NginxConfig nginxConfig(confPath);
+        NginxConfig::GlobalConfig nginxConfig(confPath);
 #if 0
         for (std::size_t i = 0; i < nginxConfig._http.server.size(); i++) {
             ListeningSocket* lSocket = new ListeningSocket(nginxConfig._http.server[i], 32768);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
 
     try {
         NginxConfig::NginxConfig nginxConfig(confPath);
-
+#if 0
         for (std::size_t i = 0; i < nginxConfig._http.server.size(); i++) {
             ListeningSocket* lSocket = new ListeningSocket(nginxConfig._http.server[i], 32768);
             if (lSocket->runSocket())
@@ -87,6 +87,7 @@ int main(int argc, char *argv[])
             }
             timer.CheckTimer(ConnectionSocket::ConnectionSocketKiller);
         }
+#endif
     } catch (const std::exception& error) {
         std::cerr << error.what() << std::endl;
         return (1);


### PR DESCRIPTION
- 평가지에 중복되는 listen 포트 처리를 하라고 명시됨
- 다른 서버 컨텍스트의 같은 listen 포트가 있는 경우 예외처리
- 한 컨텍스트 내에 같은 이름으로 여러 directive가 있는 경우 예외처리로 돌림
  (nginx configuration 파일과 조금의 차별화)
- hpp 파일에만 있던 함수들을 cpp 파일로 이전